### PR TITLE
feature(frontmatter description 노출 기능)

### DIFF
--- a/src/components/PostList/index.jsx
+++ b/src/components/PostList/index.jsx
@@ -70,7 +70,7 @@ const PostList = ({ postList }) => {
   return (
     <PostListWrapper>
       {postList.slice(0, postCount).map((post, i) => {
-        const { title, date, tags } = post.frontmatter
+        const { title, description, date, tags } = post.frontmatter
         const { excerpt } = post
         const { slug } = post.fields
 
@@ -81,7 +81,10 @@ const PostList = ({ postList }) => {
                 <Link to={slug}>{title}</Link>
               </Title>
               <Date>{date}</Date>
-              <Excerpt>{excerpt}</Excerpt>
+              { description
+                  ? <Excerpt>{description}</Excerpt>
+                  : <Excerpt>{excerpt}</Excerpt>
+              }
               <TagList tagList={tags} />
             </PostWrapper>
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -61,6 +61,7 @@ export const pageQuery = graphql`
           date(formatString: "MMMM DD, YYYY")
           update(formatString: "MMM DD, YYYY")
           title
+          description
           tags
         }
       }


### PR DESCRIPTION
## What does this PR do?
- 기존 frontmatter의 description은 블로그 목록에 표기되지 않는다.
- graphql로 frontmatter의 description 속성을 함께 받아와서 존재 여부에 따른 노출 기능이 필요하다.

## Related Links

- Issue : #136 

## 고민

- 같은 스타일을 가진 속성이기 때문에 컴포넌트 네이밍에 대한 고민이 필요한 것 같습니다. (SecondaryText?)
- 혹은, 두 컴포넌트로 분리시키는 방안도 좋을 것 같습니다. 그 이유는 excerpt는 200자 줄임으로 명시되어 있으나, description은 제한이 없을 것 같습니다. (description에 200자를 넣는 것이 쉬운 일은 아니지만...)
