### PR TITLE
fix: graphql query

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -175,7 +175,7 @@ module.exports = {
             query: `
               {
                 allMarkdownRemark(
-                  sort: { order: DESC, fields: [frontmatter___date] },
+                  sort: { frontmatter: { date: DESC } },
                   filter: { fileAbsolutePath: { regex: "/contents/posts/" } },
                 ) {
                   edges {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,7 +10,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   const result = await graphql(`
     {
       postsRemark: allMarkdownRemark(
-        sort: { fields: [frontmatter___date], order: ASC }
+        sort: { frontmatter: { date: ASC } }
         filter: { fileAbsolutePath: { regex: "/contents/posts/" } }
         limit: 1000
       ) {
@@ -25,7 +25,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
         }
       }
       tagsGroup: allMarkdownRemark(limit: 2000) {
-        group(field: frontmatter___tags) {
+        group(field: { frontmatter: { tags: SELECT } }) {
           fieldValue
         }
       }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -48,10 +48,10 @@ export const pageQuery = graphql`
       }
     }
     allMarkdownRemark(
-      sort: { fields: [frontmatter___date], order: DESC }
+      sort: { frontmatter: { date: DESC } }
       filter: { fileAbsolutePath: { regex: "/contents/posts/" } }
     ) {
-      group(field: frontmatter___tags) {
+      group(field: { frontmatter: { tags: SELECT } }) {
         fieldValue
         totalCount
       }

--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -60,7 +60,7 @@ export default Search
 export const pageQuery = graphql`
   query {
     allMarkdownRemark(
-      sort: { fields: [frontmatter___date], order: DESC }
+      sort: { frontmatter: { date: DESC } }
       filter: { fileAbsolutePath: { regex: "/contents/posts/" } }
     ) {
       nodes {

--- a/src/pages/series.jsx
+++ b/src/pages/series.jsx
@@ -65,10 +65,10 @@ export const pageQuery = graphql`
       }
     }
     allMarkdownRemark(
-      sort: { fields: [frontmatter___date], order: DESC }
+      sort: { frontmatter: { date: DESC } }
       filter: { fileAbsolutePath: { regex: "/contents/posts/" } }
     ) {
-      group(field: frontmatter___tags) {
+      group(field: { frontmatter: { tags: SELECT } }) {
         fieldValue
         totalCount
       }

--- a/src/pages/tags.jsx
+++ b/src/pages/tags.jsx
@@ -99,10 +99,10 @@ export const pageQuery = graphql`
       }
     }
     allMarkdownRemark(
-      sort: { fields: [frontmatter___date], order: DESC }
+      sort: { frontmatter: { date: DESC } }
       filter: { fileAbsolutePath: { regex: "/contents/posts/" } }
     ) {
-      group(field: frontmatter___tags) {
+      group(field: { frontmatter: { tags: SELECT } }) {
         fieldValue
         totalCount
       }

--- a/src/templates/Post.jsx
+++ b/src/templates/Post.jsx
@@ -86,7 +86,7 @@ export const pageQuery = graphql`
       }
     }
     seriesList: allMarkdownRemark(
-      sort: { order: ASC, fields: [frontmatter___date] }
+      sort: { frontmatter: { date: ASC } }
       filter: { frontmatter: { series: { eq: $series } } }
     ) {
       edges {

--- a/src/templates/Series.jsx
+++ b/src/templates/Series.jsx
@@ -90,7 +90,7 @@ export default Series
 export const pageQuery = graphql`
   query BlogSeriesBySeriesName($series: String) {
     posts: allMarkdownRemark(
-      sort: { order: ASC, fields: [frontmatter___date] }
+      sort: { frontmatter: { date: ASC } }
       filter: { frontmatter: { series: { eq: $series } } }
     ) {
       nodes {


### PR DESCRIPTION
## What does this PR do?

안녕하세요.
빌드 시에 아래 warning이 발생하더라고요.
```prolog
warn Deprecated syntax of sort and/or aggregation field arguments were found in your query (see
https://gatsby.dev/graphql-nested-sort-and-aggregate). Query was automatically converted to a new syntax. You should update query in your
code.
```

graphql 쿼리 때문인 걸 확인해서 수정했습니다.
